### PR TITLE
screen: can pass a tty when making a screen/terminal (incorporates DB changes)

### DIFF
--- a/screen.go
+++ b/screen.go
@@ -14,6 +14,8 @@
 
 package bcell
 
+import "os"
+
 // Screen represents the physical (or emulated) screen.
 // This can be a terminal window or a physical console.  Platforms implement
 // this differerently.
@@ -201,6 +203,22 @@ func NewScreen() (Screen, error) {
 	// First we attempt to obtain a terminfo screen.  This should work
 	// in most places if $TERM is set.
 	if s, e := NewTerminfoScreen(); s != nil {
+		return s, nil
+
+	} else if s, _ := NewConsoleScreen(); s != nil {
+		return s, nil
+
+	} else {
+		return nil, e
+	}
+}
+
+// NewScreenFromTty returns a Screen for the given tty (and listening for
+// SIGWINCH's on the given channel)
+func NewScreenFromTty(ttyPath string, sigwinch chan os.Signal) (Screen, error) {
+	// First we attempt to obtain a terminfo screen.  This should work
+	// in most places if $TERM is set.
+	if s, e := NewTerminfoScreenFromTty(ttyPath, sigwinch); s != nil {
 		return s, nil
 
 	} else if s, _ := NewConsoleScreen(); s != nil {

--- a/tscreen_bsd.go
+++ b/tscreen_bsd.go
@@ -33,10 +33,12 @@ func (t *tScreen) termioInit() error {
 	var ioc uintptr
 	t.tiosp = &termiosPrivate{}
 
-	if t.in, e = os.OpenFile("/dev/tty", os.O_RDONLY, 0); e != nil {
+	if t.in == nil {
+		e = fmt.Errorf("t.in unexpectedly nil (should be populated)")
 		goto failed
 	}
-	if t.out, e = os.OpenFile("/dev/tty", os.O_WRONLY, 0); e != nil {
+	if t.out == nil {
+		e = fmt.Errorf("t.out unexpectedly nil (should be populated)")
 		goto failed
 	}
 

--- a/tscreen_darwin.go
+++ b/tscreen_darwin.go
@@ -32,7 +32,7 @@ package bcell
 // a long time (probably forever) so holding one's breath is contraindicated.
 
 import (
-	"os"
+	"fmt"
 	"os/signal"
 	"syscall"
 	"unsafe"
@@ -48,10 +48,12 @@ func (t *tScreen) termioInit() error {
 	var ioc uintptr
 	t.tiosp = &termiosPrivate{}
 
-	if t.in, e = os.OpenFile("/dev/tty", os.O_RDONLY, 0); e != nil {
+	if t.in == nil {
+		e = fmt.Errorf("t.in unexpectedly nil (should be populated)")
 		goto failed
 	}
-	if t.out, e = os.OpenFile("/dev/tty", os.O_WRONLY, 0); e != nil {
+	if t.out == nil {
+		e = fmt.Errorf("t.out unexpectedly nil (should be populated)")
 		goto failed
 	}
 

--- a/tscreen_linux.go
+++ b/tscreen_linux.go
@@ -35,10 +35,12 @@ func (t *tScreen) termioInit() error {
 	var ioc uintptr
 	t.tiosp = &termiosPrivate{}
 
-	if t.in, e = os.OpenFile("/dev/tty", os.O_RDONLY, 0); e != nil {
+	if t.in == nil {
+		e = fmt.Errorf("t.in unexpectedly nil (should be populated)")
 		goto failed
 	}
-	if t.out, e = os.OpenFile("/dev/tty", os.O_WRONLY, 0); e != nil {
+	if t.out == nil {
+		e = fmt.Errorf("t.out unexpectedly nil (should be populated)")
 		goto failed
 	}
 
@@ -76,11 +78,10 @@ func (t *tScreen) termioInit() error {
 	// TCSETS.  This can leave some output unflushed.
 	ioc = uintptr(syscall.TCSETS)
 	if _, _, e1 := syscall.Syscall6(syscall.SYS_IOCTL, fd, ioc, tios, 0, 0, 0); e1 != 0 {
+		log.Printf("HUH %v", e1)
 		e = e1
 		goto failed
 	}
-
-	signal.Notify(t.sigwinch, syscall.SIGWINCH)
 
 	if w, h, e := t.getWinSize(); e == nil && w != 0 && h != 0 {
 		t.cells.Resize(w, h)

--- a/tscreen_linux.go
+++ b/tscreen_linux.go
@@ -21,8 +21,6 @@ import (
 	"os/signal"
 	"syscall"
 	"unsafe"
-
-	"log"
 )
 
 type termiosPrivate syscall.Termios
@@ -78,10 +76,11 @@ func (t *tScreen) termioInit() error {
 	// TCSETS.  This can leave some output unflushed.
 	ioc = uintptr(syscall.TCSETS)
 	if _, _, e1 := syscall.Syscall6(syscall.SYS_IOCTL, fd, ioc, tios, 0, 0, 0); e1 != 0 {
-		log.Printf("HUH %v", e1)
 		e = e1
 		goto failed
 	}
+
+	signal.Notify(t.sigwinch, syscall.SIGWINCH)
 
 	if w, h, e := t.getWinSize(); e == nil && w != 0 && h != 0 {
 		t.cells.Resize(w, h)

--- a/tscreen_posix.go
+++ b/tscreen_posix.go
@@ -128,10 +128,12 @@ func (t *tScreen) termioInit() error {
 	var newtios C.struct_termios
 	var fd C.int
 
-	if t.in, e = os.OpenFile("/dev/tty", os.O_RDONLY, 0); e != nil {
+	if t.in == nil {
+		e = fmt.Errorf("t.in unexpectedly nil (should be populated)")
 		goto failed
 	}
-	if t.out, e = os.OpenFile("/dev/tty", os.O_WRONLY, 0); e != nil {
+	if t.out == nil {
+		e = fmt.Errorf("t.out unexpectedly nil (should be populated)")
 		goto failed
 	}
 


### PR DESCRIPTION
Hello @landism, @dbentley,

Please review the following commits I made in branch maiamcc/pass-tty:

3ee63c22a389d19ab0da8d6c58a054313571adfb (2018-10-02 18:17:31 -0400)
screen: can pass a tty when making a screen/terminal (incorporates DB changes)

72997e9b18712cc1a3831951c27720a5b52a2f96 (2018-10-02 18:12:50 -0400)
another one

ce6acb91c2c0b70f61a98f84715da61ba8a4d229 (2018-10-02 18:12:50 -0400)
vendoring

bb9c49c3d11000f010c7b3f4db415c06ec05b668 (2018-10-02 18:12:46 -0400)
tcell -> bcell

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics